### PR TITLE
Fix automerge job

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   test:
-    runs-on: [ self-hosted, dcam ]
+    runs-on: [self-hosted, dcam]
     permissions:
       actions: write
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Test
         working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{env.BUILD_TYPE}} -L dcam --output-on-failure
+        run: ctest -C ${{env.BUILD_TYPE}} -L acquire-driver-hdcam --output-on-failure
 
   auto-merge:
     name: "Auto-merge Dependabot PRs"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,10 +1,7 @@
-name: Tests
+name: Test and merge
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  pull_request_target:
     branches:
       - main
 
@@ -54,3 +51,29 @@ jobs:
       - name: Test
         working-directory: ${{github.workspace}}/build
         run: ctest -C ${{env.BUILD_TYPE}} -L dcam --output-on-failure
+
+  auto-merge:
+    name: "Auto-merge Dependabot PRs"
+    needs: test
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: "Get Dependabot metadata"
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: ${{ github.token }}
+
+      - name: "Approve the PR"
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.PAT }}
+
+      # Don't auto-merge major version updates
+      - name: "Auto-merge the PR"
+        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test:
-    runs-on: [ self-hosted, dcam ]
+    runs-on: [self-hosted, dcam]
     permissions:
       actions: write
 
@@ -53,4 +53,4 @@ jobs:
 
       - name: Test
         working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{env.BUILD_TYPE}} -L dcam --output-on-failure
+        run: ctest -C ${{env.BUILD_TYPE}} -L acquire-driver-hdcam --output-on-failure

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
         )
 
         add_test(NAME test-${tgt} COMMAND ${tgt})
-        set_tests_properties(test-${tgt} PROPERTIES LABELS dcam)
+        set_tests_properties(test-${tgt} PROPERTIES LABELS acquire-driver-hdcam)
     endforeach()
 
     #


### PR DESCRIPTION
Fixes an error in the Dependabot automerge job where tests would be run against the main branch rather than the ref branch.