### PR TITLE
don't build the tests for acquire test dependencies

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,10 @@
 if(${NOTEST})
     message(STATUS "Skipping test targets")
 else()
+    set(NOTEST "TRUE")
     aq_require(acquire-video-runtime)
     aq_require(acquire-driver-common)
+    set(NOTEST "FALSE")
 
     #
     # PARAMETERS


### PR DESCRIPTION
This resolves a failure to build tests that we're currently experiencing on main.

Tests pull in acquire libraries (like `acquire-driver-common` and `acquire-video-runtime`) as dependencies. These are brought in as submodules and compiled with the tests.

Doing things this way, also causes the tests in the dependencies. That can be nice because we make sure the dependencies are running correctly, but it introduces all kinds of build shenanigans and is somewhat wasteful. We tend to have good observability on whether the dependencies are working anyway.

So this PR uses the `NOTEST` variable in the `test/CMakeLists.txt` to turn off the building of tests in dependencies.

