### PR TITLE
Fix setting ROI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.6](https://github.com/acquire-project/acquire-driver-hdcam/compare/v0.1.5...v0.1.6) - 2023-08-10
 
 - Fixes a bug where the output trigger source property was set when it shouldn't be.
+- Fixes a bug where roi bound checking wasn't working.
 
 ## [0.1.5](https://github.com/acquire-project/acquire-driver-hdcam/compare/v0.1.4...v0.1.5) - 2023-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.6](https://github.com/acquire-project/acquire-driver-hdcam/compare/v0.1.5...v0.1.6) - 2023-08-10
+## [0.1.6](https://github.com/acquire-project/acquire-driver-hdcam/compare/v0.1.5...v0.1.6) - 2023-08-15
 
 - Fixes a bug where the output trigger source property was set when it shouldn't be.
 - Fixes a bug where roi bound checking wasn't working.

--- a/src/dcam.camera.c
+++ b/src/dcam.camera.c
@@ -527,10 +527,6 @@ aq_dcam_set__inner(struct Dcam4Camera* self,
           prop_write(u32, hdcam, DCAM_IDPROP_SUBARRAYVPOS, &props->offset.y);
         is_ok &=
           prop_write(u32, hdcam, DCAM_IDPROP_SUBARRAYHPOS, &props->offset.x);
-
-        is_ok &= (dcamprop_setvalue(hdcam,
-                                    DCAM_IDPROP_SUBARRAYMODE,
-                                    DCAMPROP_MODE__ON) == DCAMERR_SUCCESS);
     }
 
     // exposure

--- a/src/dcam.camera.c
+++ b/src/dcam.camera.c
@@ -366,13 +366,13 @@ aq_dcam_get_metadata__inner(const struct Dcam4Camera* self,
       &metadata->readout_direction, DCAM_IDPROP_READOUT_DIRECTION, 1.0f);
 
     is_ok &=
-      READ_PROP_META(&metadata->offset.x, DCAM_IDPROP_SUBARRAYHPOS, 1.0f);
-    is_ok &=
-      READ_PROP_META(&metadata->offset.y, DCAM_IDPROP_SUBARRAYVPOS, 1.0f);
-    is_ok &=
       READ_PROP_META(&metadata->shape.x, DCAM_IDPROP_SUBARRAYHSIZE, 1.0f);
     is_ok &=
       READ_PROP_META(&metadata->shape.y, DCAM_IDPROP_SUBARRAYVSIZE, 1.0f);
+    is_ok &=
+      READ_PROP_META(&metadata->offset.x, DCAM_IDPROP_SUBARRAYHPOS, 1.0f);
+    is_ok &=
+      READ_PROP_META(&metadata->offset.y, DCAM_IDPROP_SUBARRAYVPOS, 1.0f);
 
 #undef READ_PROP_META
 

--- a/src/dcam.camera.c
+++ b/src/dcam.camera.c
@@ -1,5 +1,6 @@
 #include "dcam.camera.h"
 #include "device/props/device.h"
+#include "device/props/metadata.h"
 #include "logger.h"
 
 #include "dcam.error.h"
@@ -513,15 +514,23 @@ aq_dcam_set__inner(struct Dcam4Camera* self,
     // roi
     if (IS_CHANGED(offset.x) || IS_CHANGED(offset.y) || IS_CHANGED(shape.x) ||
         IS_CHANGED(shape.y)) {
-        dcamprop_setvalue(hdcam, DCAM_IDPROP_SUBARRAYMODE, DCAMPROP_MODE__ON);
-        is_ok &=
-          prop_write(u32, hdcam, DCAM_IDPROP_SUBARRAYHPOS, &props->offset.x);
-        is_ok &=
-          prop_write(u32, hdcam, DCAM_IDPROP_SUBARRAYVPOS, &props->offset.y);
+        is_ok &= (dcamprop_setvalue(hdcam,
+                                    DCAM_IDPROP_SUBARRAYMODE,
+                                    DCAMPROP_MODE__ON) == DCAMERR_SUCCESS);
+
         is_ok &=
           prop_write(u32, hdcam, DCAM_IDPROP_SUBARRAYHSIZE, &props->shape.x);
         is_ok &=
           prop_write(u32, hdcam, DCAM_IDPROP_SUBARRAYVSIZE, &props->shape.y);
+
+        is_ok &=
+          prop_write(u32, hdcam, DCAM_IDPROP_SUBARRAYVPOS, &props->offset.y);
+        is_ok &=
+          prop_write(u32, hdcam, DCAM_IDPROP_SUBARRAYHPOS, &props->offset.x);
+
+        is_ok &= (dcamprop_setvalue(hdcam,
+                                    DCAM_IDPROP_SUBARRAYMODE,
+                                    DCAMPROP_MODE__ON) == DCAMERR_SUCCESS);
     }
 
     // exposure

--- a/src/dcam.getset.c
+++ b/src/dcam.getset.c
@@ -50,11 +50,18 @@ prop_write_u32(HDCAM hdcam,
                const char* prop_name)
 {
     double v = *value;
-    DCAM(dcamprop_setgetvalue(hdcam, prop_id, &v, 0));
+    DCAMERR ecode;
+    DCAM(ecode = dcamprop_setgetvalue(hdcam, prop_id, &v, 0));
     *value = (uint32_t)v;
     return 1;
 Error:
-    LOG("Failed to write %s", prop_name);
+    char buf[256] = { 0 };
+    DCAMDEV_STRING param = { .size = sizeof(param),
+                             .iString = ecode,
+                             .text = buf,
+                             .textbytes = sizeof(buf) };
+    dcamdev_getstring(hdcam, &param);
+    LOG("Failed to write %s. %s", prop_name, buf);
     return 0;
 }
 

--- a/src/dcam.getset.c
+++ b/src/dcam.getset.c
@@ -55,7 +55,7 @@ prop_write_u32(HDCAM hdcam,
     *value = (uint32_t)v;
     return 1;
 Error:
-    LOG("Failed to write %s. %s", prop_name, buf);
+    LOG("Failed to write %s.", prop_name);
     return 0;
 }
 

--- a/src/dcam.getset.c
+++ b/src/dcam.getset.c
@@ -55,12 +55,6 @@ prop_write_u32(HDCAM hdcam,
     *value = (uint32_t)v;
     return 1;
 Error:
-    char buf[256] = { 0 };
-    DCAMDEV_STRING param = { .size = sizeof(param),
-                             .iString = ecode,
-                             .text = buf,
-                             .textbytes = sizeof(buf) };
-    dcamdev_getstring(hdcam, &param);
     LOG("Failed to write %s. %s", prop_name, buf);
     return 0;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ else()
         dcam-reset-on-fail
         one-video-stream
         set-output-trigger
+        set-roi
     )
 
     foreach(name ${tests})

--- a/tests/set-roi.cpp
+++ b/tests/set-roi.cpp
@@ -74,7 +74,7 @@ setup(AcquireRuntime* runtime)
 
     ASSERT_EQ(int, "%d", props.video[0].camera.settings.shape.x, 1700);
     ASSERT_EQ(int, "%d", props.video[0].camera.settings.shape.y, 512);
-    ASSERT_EQ(int, "%d", props.video[0].camera.settings.offset.x, 804);
+    ASSERT_EQ(int, "%d", props.video[0].camera.settings.offset.x, 304);
     ASSERT_EQ(int, "%d", props.video[0].camera.settings.offset.y, 896);
     return 1;
 Error:

--- a/tests/set-roi.cpp
+++ b/tests/set-roi.cpp
@@ -1,0 +1,88 @@
+//! Test: Runs through setting up acquiring from a sub-rectangle of the sensor
+#include "acquire.h"
+#include "device/hal/device.manager.h"
+#include "device/props/components.h"
+#include "logger.h"
+#include <stdio.h>
+#include <string.h>
+
+#define L (aq_logger)
+#define LOG(...) L(0, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+#define ERR(...) L(1, __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+#define CHECK(e)                                                               \
+    do {                                                                       \
+        if (!(e)) {                                                            \
+            ERR("Expression evaluated as false: " #e);                         \
+            goto Error;                                                        \
+        }                                                                      \
+    } while (0)
+#define DEVOK(e) CHECK(Device_Ok == (e))
+#define OK(e) CHECK(AcquireStatus_Ok == (e))
+
+#define countof(e) (sizeof(e) / sizeof(*(e)))
+
+void
+reporter(int is_error,
+         const char* file,
+         int line,
+         const char* function,
+         const char* msg)
+{
+    fprintf(is_error ? stderr : stdout,
+            "%s%s(%d) - %s: %s\n",
+            is_error ? "ERROR " : "",
+            file,
+            line,
+            function,
+            msg);
+}
+
+int
+setup(AcquireRuntime* runtime)
+{
+    AcquireProperties props = {};
+
+    const DeviceManager* dm = 0;
+    CHECK(dm = acquire_device_manager(runtime));
+
+#define SIZED(s) s, sizeof(s) - 1
+    DEVOK(device_manager_select(dm,
+                                DeviceKind_Camera,
+                                SIZED("Hamamatsu C15440-20UP.*"),
+                                &props.video[0].camera.identifier));
+    DEVOK(device_manager_select(dm,
+                                DeviceKind_Storage,
+                                SIZED("Trash"),
+                                &props.video[0].storage.identifier));
+#undef SIZED
+
+    props.video[0].max_frame_count = 10;
+    props.video[0].camera.settings.shape = { .x = 1700, .y = 512 };
+    props.video[0].camera.settings.offset = { .x = 302, .y = 896 };
+    OK(acquire_configure(runtime, &props));
+    // Expect that the roi is what we intended.
+    CHECK(props.video[0].camera.settings.shape.x == 1700);
+    CHECK(props.video[0].camera.settings.shape.y == 512);
+    CHECK(props.video[0].camera.settings.offset.x == 302);
+    CHECK(props.video[0].camera.settings.offset.y == 896);
+    return 1;
+Error:
+    return 0;
+}
+
+int
+main()
+{
+    int ecode = 0;
+    AcquireRuntime* runtime = 0;
+    CHECK(runtime = acquire_init(reporter));
+    CHECK(setup(runtime));
+    OK(acquire_start(runtime));
+    OK(acquire_stop(runtime));
+Finalize:
+    acquire_shutdown(runtime);
+    return ecode;
+Error:
+    ecode = 1;
+    goto Finalize;
+}

--- a/tests/set-roi.cpp
+++ b/tests/set-roi.cpp
@@ -74,7 +74,7 @@ setup(AcquireRuntime* runtime)
 
     ASSERT_EQ(int, "%d", props.video[0].camera.settings.shape.x, 1700);
     ASSERT_EQ(int, "%d", props.video[0].camera.settings.shape.y, 512);
-    ASSERT_EQ(int, "%d", props.video[0].camera.settings.offset.x, 304);
+    ASSERT_EQ(int, "%d", props.video[0].camera.settings.offset.x, 804);
     ASSERT_EQ(int, "%d", props.video[0].camera.settings.offset.y, 896);
     return 1;
 Error:


### PR DESCRIPTION
closes #85 

adds test, updates changelog

Changes the ROI setting procedure so it's more robust:
1. Set offset to 0, so size can have full range of sensor.
2. Set the size
3. Set the offset

Sometimes the offset has to be divisible by 4. When setting a parameter that is not appropriately divisible, the call just fails with an invalid parameter which is not very helpful.

Fortunately, when running in "progressive" mode (the default for light-sheet), there are fewer restrictions. I'm not exactly sure how to query the restrictions, so the approach for this PR is to make sure we're setting the mode early.

