### PR TITLE
execute_trigger forces a software trigger in all modes

### DIFF
--- a/src/dcam.camera.c
+++ b/src/dcam.camera.c
@@ -895,7 +895,7 @@ aq_dcam_fire_software_trigger(struct Camera* self_)
 
     if (trigger_source != DCAMPROP_TRIGGERSOURCE__SOFTWARE) {
 
-        // Force a software trigger, by temporarily disabling external
+        // Force a software trigger by temporarily disabling external
         // triggering, firing a software trigger, and re-enabling the
         // external trigger.
 

--- a/tests/abort-finite-acquisition.cpp
+++ b/tests/abort-finite-acquisition.cpp
@@ -89,7 +89,8 @@ main()
         };
         props.video[0].camera.settings.exposure_time_us = 1e4;
         props.video[0].max_frame_count = 10;
-        props.video[0].camera.settings.input_triggers.frame_start.line = 0;
+        props.video[0].camera.settings.input_triggers.frame_start.line =
+          0; // Ext. Trig
         props.video[0].camera.settings.input_triggers.frame_start.enable = 1;
 
         OK(acquire_configure(runtime, &props));


### PR DESCRIPTION
closes #194 
depends on acquire-project/acquire-common#34

Changes the `execute_trigger` behavior to force a software trigger when called regardless of the camera configuration. This helps with `acquire_abort()`.

Interestingly, we seem to already have an `abort-finite-acquisition` test. I wonder if it can be improved to cover the problem Micah ran into. May need to just add a check that the everything is restartable after the abort.