### PR TITLE
upgrade to dcamsdk4 v24.8.6894

### DIFF
--- a/cmake/hdcam.cmake
+++ b/cmake/hdcam.cmake
@@ -7,7 +7,9 @@
 # folders should be on the system path.
 find_path(DCAMSDK_ROOT_DIR
     NAMES "dcamsdk4/inc/dcamapi4.h"
-    PATH_SUFFIXES "Hamamatsu_DCAMSDK4_v22126552"
+    PATH_SUFFIXES 
+        "Hamamatsu_DCAMSDK4_v24026764"
+        "Hamamatsu_DCAMSDK4_v22126552"
     DOC "Hamamatsu DCAM-SDK location"
     NO_CACHE
 )


### PR DESCRIPTION
This PR just updates `hdcam.cmake` to add "Hamamatsu_DCAMSDK4_v24026764" to the cmake search path when looking for the library.

I also added this to Ghanima. So this PR is also demonstrating that the self-hosted runner on that machine is working as expected.

- I looked to make sure that the right version is being picked up in the config step. see [here](https://github.com/acquire-project/acquire-driver-hdcam/actions/runs/10604663052/job/29391807106?pr=213#step:7:64).